### PR TITLE
Use externally-provided flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@ ifeq ($(jansson),)
 libs=$(shell pkg-config --libs jansson)
 else
 libs=$(jansson)/src/.libs/libjansson.a
-INCLUDE=-I$(jansson)/src
+CPPFLAGS+=-I$(jansson)/src
 endif
-CFLAGS+=-W -Wall $(INCLUDE)
+CFLAGS?=-W -Wall
 
 all: check-libs plotnetcfg
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ else
 libs=$(jansson)/src/.libs/libjansson.a
 INCLUDE=-I$(jansson)/src
 endif
-CFLAGS=-W -Wall $(INCLUDE)
+CFLAGS+=-W -Wall $(INCLUDE)
 
 all: check-libs plotnetcfg
 
@@ -13,7 +13,7 @@ plotnetcfg: args.o ethtool.o frontend.o handler.o if.o label.o main.o match.o ne
 	    handlers/bridge.o handlers/master.o handlers/openvswitch.o handlers/veth.o \
 	    handlers/vlan.o \
 	    frontends/dot.o frontends/json.o
-	gcc -o $@ $+ $(libs)
+	gcc $(LDFLAGS) -o $@ $+ $(libs)
 
 args.o: args.c args.h
 ethtool.o: ethtool.c ethtool.h


### PR DESCRIPTION
This allows CFLAGS and LDFLAGS to be provided externally, which helps with packaging for distributions...
