### PR TITLE
Some build-type cleanups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ else
 libs=$(jansson)/src/.libs/libjansson.a
 INCLUDE=-I$(jansson)/src
 endif
-CFLAGS=-W -Wall $(INCLUDE)
+
+CFLAGS=-W -Wall $(INCLUDE) $(EXTRA_CFLAGS)
 
 all: check-libs plotnetcfg
 
@@ -13,7 +14,7 @@ plotnetcfg: args.o ethtool.o frontend.o handler.o if.o label.o main.o match.o ne
 	    handlers/bridge.o handlers/master.o handlers/openvswitch.o handlers/veth.o \
 	    handlers/vlan.o \
 	    frontends/dot.o frontends/json.o
-	gcc -o $@ $+ $(libs)
+	$(CC) $(LDFLAGS) -o $@ $+ $(libs)
 
 args.o: args.c args.h
 ethtool.o: ethtool.c ethtool.h

--- a/README
+++ b/README
@@ -30,6 +30,11 @@ invoke:
 
 make
 
+The following flags can be overridden during the build:
+- CC
+  Choose a different compiler (such as clang or an arm cross compiler)
+- EXTRA_CFLAGS
+  Additional compilation flags to pass to the compiler
 
 Bugs:
 

--- a/handlers/openvswitch.c
+++ b/handlers/openvswitch.c
@@ -411,8 +411,10 @@ static int check_vport(struct netns_entry *ns, struct if_entry *entry)
 	oh.dp_ifindex = 0;
 	len = nla_add_str(&oh, sizeof(oh), OVS_VPORT_ATTR_NAME, entry->if_name,
 			  &payload);
-	if (!len)
+	if (!len) { 
+		err = ENOMEM;
 		goto out_hnd;
+	}
 	err = genl_request(&hnd, vport_genl_id, OVS_VPORT_CMD_GET,
 			   payload, len, &dest);
 	if (err)


### PR DESCRIPTION
Just a few cleanups to allow multiple compilers to be used (allowing xcompile to, for instance, arm), as well as a possible invalid exit return code.
