### PR TITLE
Optionally filter loopback interfaces and v6 link locals for dot output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ plotnetcfg
 version.h
 tags
 Makefile.dep
+*.swp

--- a/frontend.c
+++ b/frontend.c
@@ -31,6 +31,8 @@ static struct output_entry default_output = {
 	.format = "dot",
 	.file = NULL,
 	.print_mask = -1U,
+	.filter_loopback = false,
+	.filter_ipv6_linklocal = false,
 };
 
 static struct output_entry *output = NULL;
@@ -109,6 +111,28 @@ static int set_nostate()
 	return 0;
 }
 
+static int set_loopback()
+{
+	int err;
+
+	if ((err = require_format()))
+		return err;
+
+	output->filter_loopback = true;
+	return 0;
+}
+
+static int set_v6_linklocal()
+{
+	int err;
+
+	if ((err = require_format()))
+		return err;
+
+	output->filter_ipv6_linklocal = true;
+	return 0;
+}
+
 static int print_formats(_unused char *arg)
 {
 	struct frontend *f;
@@ -135,6 +159,14 @@ static struct arg_option options[] = {
 	{ .long_name = "list-formats", .short_name = 'F',
 	  .type = ARG_CALLBACK, .action.callback = print_formats,
 	  .help = "list available output formats",
+	},
+	{ .long_name = "filter-loopback", .short_name = 'l', .has_arg = 0,
+	  .type = ARG_CALLBACK, .action.callback = set_loopback,
+	  .help = "don't output loopback interfaces (dot only)",
+	},
+	{ .long_name = "filter-v6-local", .short_name = 'L', .has_arg = 0,
+	  .type = ARG_CALLBACK, .action.callback = set_v6_linklocal,
+	  .help = "don't output v6 link-local addresses (dot only)",
 	},
 };
 

--- a/frontend.h
+++ b/frontend.h
@@ -15,6 +15,8 @@
 
 #ifndef _FRONTEND_H
 #define _FRONTEND_H
+#include <stdbool.h>
+
 #include "netns.h"
 
 struct output_entry {
@@ -22,6 +24,8 @@ struct output_entry {
 	char *format, *file;
 	struct frontend *frontend;
 	unsigned int print_mask;
+	bool filter_loopback;
+	bool filter_ipv6_linklocal;
 };
 
 struct frontend {

--- a/frontends/dot.c
+++ b/frontends/dot.c
@@ -68,8 +68,8 @@ static void output_ifaces_pass1(FILE *f, struct if_entry *list, struct output_en
 	struct if_entry *ptr;
 
 	for (ptr = list; ptr; ptr = ptr->next) {
-    if ((out->filter_loopback) && (ptr->flags & IF_LOOPBACK))
-      continue;
+		if ((out->filter_loopback) && (ptr->flags & IF_LOOPBACK))
+			continue;
 		fprintf(f, "\"%s\" [label=\"%s", ifid(ptr), ptr->if_name);
 		if (ptr->driver)
 			fprintf(f, " (%s)", ptr->driver);

--- a/frontends/dot.c
+++ b/frontends/dot.c
@@ -68,7 +68,7 @@ static void output_ifaces_pass1(FILE *f, struct if_entry *list, struct output_en
 	struct if_entry *ptr;
 
 	for (ptr = list; ptr; ptr = ptr->next) {
-    if ((out->filter_loopback) && (strlen(ptr->if_name) == 2) && (!strncmp(ptr->if_name, "lo", 2)))
+    if ((out->filter_loopback) && (ptr->flags & IF_LOOPBACK))
       continue;
 		fprintf(f, "\"%s\" [label=\"%s", ifid(ptr), ptr->if_name);
 		if (ptr->driver)

--- a/frontends/dot.c
+++ b/frontends/dot.c
@@ -14,6 +14,7 @@
  */
 
 #include <stdio.h>
+#include <string.h>
 #include <sys/socket.h>
 #include <time.h>
 #include "../frontend.h"
@@ -23,6 +24,7 @@
 #include "../netns.h"
 #include "../utils.h"
 #include "../version.h"
+#include "../args.h"
 #include "dot.h"
 
 static void output_label(FILE *f, struct label *list)
@@ -42,11 +44,13 @@ static void output_label_properties(FILE *f, struct label_property *list, unsign
 			fprintf(f, "\\n%s: %s", ptr->key, ptr->value);
 }
 
-static void output_addresses(FILE *f, struct if_addr_entry *list)
+static void output_addresses(FILE *f, struct if_addr_entry *list, struct output_entry *out)
 {
 	struct if_addr_entry *ptr;
 
 	for (ptr = list; ptr; ptr = ptr->next) {
+    if ((out->filter_ipv6_linklocal) & (!strncmp(ptr->addr.formatted, "fe80", 4)))
+      continue;
 		fprintf(f, "\\n%s", ptr->addr.formatted);
 		if (ptr->peer.formatted)
 			fprintf(f, " peer %s", ptr->peer.formatted);
@@ -59,21 +63,23 @@ static void output_mtu(FILE *f, struct if_entry *ptr)
 		fprintf(f, "\\nMTU %d", ptr->mtu);
 }
 
-static void output_ifaces_pass1(FILE *f, struct if_entry *list, unsigned int prop_mask)
+static void output_ifaces_pass1(FILE *f, struct if_entry *list, struct output_entry *out)
 {
 	struct if_entry *ptr;
 
 	for (ptr = list; ptr; ptr = ptr->next) {
+    if ((out->filter_loopback) && (strlen(ptr->if_name) == 2) && (!strncmp(ptr->if_name, "lo", 2)))
+      continue;
 		fprintf(f, "\"%s\" [label=\"%s", ifid(ptr), ptr->if_name);
 		if (ptr->driver)
 			fprintf(f, " (%s)", ptr->driver);
-		output_label_properties(f, ptr->prop, prop_mask);
+		output_label_properties(f, ptr->prop, out->print_mask);
 		output_mtu(f, ptr);
-		if (label_prop_match_mask(IF_PROP_CONFIG, prop_mask))
-			output_addresses(f, ptr->addr);
+		if (label_prop_match_mask(IF_PROP_CONFIG, out->print_mask))
+			output_addresses(f, ptr->addr, out);
 		fprintf(f, "\"");
 
-		if (label_prop_match_mask(IF_PROP_STATE, prop_mask)) {
+		if (label_prop_match_mask(IF_PROP_STATE, out->print_mask)) {
 			if (ptr->flags & IF_INTERNAL)
 				fprintf(f, ",style=dotted");
 			else if (!(ptr->flags & IF_UP))
@@ -89,7 +95,7 @@ static void output_ifaces_pass1(FILE *f, struct if_entry *list, unsigned int pro
 	}
 }
 
-static void output_ifaces_pass2(FILE *f, struct if_entry *list)
+static void output_ifaces_pass2(FILE *f, struct if_entry *list, struct output_entry *out)
 {
 	struct if_entry *ptr;
 
@@ -154,12 +160,12 @@ static void dot_output(FILE *f, struct netns_entry *root, struct output_entry *o
 			fprintf(f, "label=\"%s\"\n", ns->name);
 			fprintf(f, "fontcolor=\"black\"\n");
 		}
-		output_ifaces_pass1(f, ns->ifaces, output_entry->print_mask);
+		output_ifaces_pass1(f, ns->ifaces, output_entry);
 		if (ns->name)
 			fprintf(f, "}\n");
 	}
 	for (ns = root; ns; ns = ns->next) {
-		output_ifaces_pass2(f, ns->ifaces);
+		output_ifaces_pass2(f, ns->ifaces, output_entry);
 	}
 	output_warnings(f, root);
 	fprintf(f, "}\n");


### PR DESCRIPTION
Add useful filters to clean up dot output in some cases.  Sets up the ability to add more general filters, although didn't actually apply them to JSON in this case because that is much easier to handle on the client side than the dot output can.
